### PR TITLE
Fix: Flickering Sidebar On Load

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,32 +3,33 @@ import {Geist, Geist_Mono} from "next/font/google";
 import "./globals.css";
 import React from "react";
 import {SidebarProvider} from "@/components/ui/sidebar";
-import {UserSidebar, UserSidebarTrigger} from "@/components/user-sidebar";
+import {ClientSidebarTrigger} from "@/components/sidebar/client-sidebar";
 import {Toaster} from "@/components/ui/sonner";
 import {UserProvider} from "@/components/providers/user-provider";
 import {Footer} from "@/components/footer";
 import {ThemeProvider} from "@/components/providers/theme-provider";
+import ServerSidebar from "@/components/sidebar/server-sidebar";
 
 const geistSans = Geist({
-    variable: "--font-geist-sans",
-    subsets: ["latin"],
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
 });
 
 const geistMono = Geist_Mono({
-    variable: "--font-geist-mono",
-    subsets: ["latin"],
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
 });
 
 export const metadata: Metadata = {
-    title: "Kummerkasten",
-    description: "Kummerkasten der Fachschaft",
-    keywords: ["kummerkasten", "fachschaft", "mathphysinfo", "uni heidelberg"]
+  title: "Kummerkasten",
+  description: "Kummerkasten der Fachschaft",
+  keywords: ["kummerkasten", "fachschaft", "mathphysinfo", "uni heidelberg"]
 };
 
 export default function UserLayout({
-                                       children,
+                                     children,
                                    }: Readonly<{
-    children: React.ReactNode;
+  children: React.ReactNode;
 }>) {
   return (
     <html lang="de" suppressHydrationWarning>
@@ -38,9 +39,9 @@ export default function UserLayout({
     <ThemeProvider attribute={'class'} defaultTheme={"system"}>
       <UserProvider>
         <SidebarProvider>
-          <UserSidebar/>
-           <main className={'w-full h-full flex flex-col justify-between min-h-screen'}>
-            <UserSidebarTrigger/>
+          <ServerSidebar/>
+          <main className={'w-full h-full flex flex-col justify-between min-h-screen'}>
+            <ClientSidebarTrigger/>
             {children}
             <Footer/>
           </main>

--- a/frontend/components/sidebar/client-sidebar.tsx
+++ b/frontend/components/sidebar/client-sidebar.tsx
@@ -1,6 +1,5 @@
 "use client"
 import {
-  Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
@@ -18,7 +17,8 @@ import {useRouter} from "next/navigation";
 import {useTheme} from "next-themes";
 import {useEffect, useState} from "react";
 import {clsx} from "clsx";
-export function UserSidebar() {
+
+export function ClientSidebar() {
   const {user, logout} = useUser()
   const router = useRouter()
   const {open, isMobile} = useSidebar()
@@ -47,7 +47,7 @@ export function UserSidebar() {
   if (!user) return null
 
   return (
-    <Sidebar className={'fixed h-screen top-0 left-0'} collapsible={"icon"} data-cy={'sidebar'}>
+    <>
       <SidebarContent className={'pr-10'}>
         {!isMobile && (
           <SidebarTrigger
@@ -85,42 +85,43 @@ export function UserSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-     <SidebarFooter>
-                <SidebarMenu>
-                    <SidebarMenuItem>
-                        <ThemeSwitch/>
-                    </SidebarMenuItem>
-                    <SidebarMenuItem>
-                        <SidebarMenuButton
-                            data-cy={'sidebar-settings'}
-                            onClick={() => router.push("/account")}
-                            className={'flex items-center'}
-                        >
-                            <Settings/> Einstellungen
-                        </SidebarMenuButton>
-                    </SidebarMenuItem>
-                    <SidebarMenuItem>
-                        <SidebarMenuButton
-                            data-cy={'sidebar-logout'}
-                            onClick={() => logout()}
-                            className={'flex items-center text-destructive'}
-                        >
-                            <LogOut className={'stroke-destructive'}/> Logout
-                        </SidebarMenuButton>
-                    </SidebarMenuItem>
-                </SidebarMenu>
-            </SidebarFooter>
-        </Sidebar>
-    );
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <ThemeSwitch/>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              data-cy={'sidebar-settings'}
+              onClick={() => router.push("/account")}
+              className={'flex items-center'}
+            >
+              <Settings/> Einstellungen
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              data-cy={'sidebar-logout'}
+              onClick={() => logout()}
+              className={'flex items-center text-destructive'}
+            >
+              <LogOut className={'stroke-destructive'}/> Logout
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </>
+  );
 
-  }
+}
 
-export function UserSidebarTrigger() {
+export function ClientSidebarTrigger() {
   const {user} = useUser();
   const {isMobile} = useSidebar()
   if (!user || !isMobile) return null;
   return <SidebarTrigger data-cy={'sidebar-trigger'}/>
 }
+
 function ThemeSwitch() {
   const [mounted, setMounted] = useState(false)
   const {resolvedTheme, theme, setTheme} = useTheme()

--- a/frontend/components/sidebar/server-sidebar.tsx
+++ b/frontend/components/sidebar/server-sidebar.tsx
@@ -1,0 +1,10 @@
+import {ClientSidebar} from "@/components/sidebar/client-sidebar";
+import {Sidebar} from "@/components/ui/sidebar";
+
+export default function ServerSidebar() {
+  return (
+    <Sidebar className={'fixed h-screen top-0 left-0'} collapsible={"icon"} data-cy={'sidebar'}>
+      <ClientSidebar/>
+    </Sidebar>
+  )
+}


### PR DESCRIPTION
The buttons still render in later, but with the rest of the page and with this there is no content jumping around

Fixes #118 