### PR TITLE
Bug: updateLabel with no name change broken

### DIFF
--- a/server/graph/schema.resolvers.go
+++ b/server/graph/schema.resolvers.go
@@ -270,12 +270,12 @@ func (r *mutationResolver) UpdateLabel(ctx context.Context, id string, label mod
 
 		if err := r.DB.NewSelect().Model(&labels).
 			Where("LOWER(name) = ?", strings.ToLower(*label.Name)).
-			Scan(ctx); err != nil {
+			Where("id != ?", dbLabel.ID).Scan(ctx); err != nil {
 			return "", err
 		}
 
 		if len(labels) != 0 {
-			return "", fmt.Errorf("unique constraint error: label with name %v does already exist", label.Name)
+			return "", fmt.Errorf("unique constraint error: label with name %v does already exist", *label.Name)
 		}
 
 		dbLabel.Name = *label.Name


### PR DESCRIPTION
When the updateLabel mutation in backend/graph/schema.resolvers.go hat the uniqueness check on the name implemented, I forgot to exclude the name of the label that's being updated from the check. The error did not occur as the functionality was only tested in the playground, and I (propably) did not test the updateLabel function for a label with the name being changed to the same name it currently had. This issue (#229  ) is fixed in this PR.
Also didn't liked the error that gave me just the pointer on the name, so I dereferenced it.