### PR TITLE
Fix: Sidebar Wrapping Last Changed Weirdly

### DIFF
--- a/frontend/app/tickets/[ticketId]/ticket-sidebar.tsx
+++ b/frontend/app/tickets/[ticketId]/ticket-sidebar.tsx
@@ -316,7 +316,7 @@ export default function TicketSidebar({
                 {t.title}
               </div>
               <div
-                className="hidden md:flex text-xs items-center text-muted-foreground truncate shrink"
+                className="hidden md:flex text-xs items-center text-muted-foreground truncate"
                 title={`Geändert: ${t?.lastModified ? format(new Date(t.lastModified), "dd.MM.yy") : ""}`}
               >
                 Geändert: {t?.lastModified ? format(new Date(t.lastModified), "dd.MM.yy") : ""}


### PR DESCRIPTION
Fixes #218 


I think there is still some improvements to be made to the sidebar:
- long titles squish the last changed part
- short titles allow the last changed part to go out of formation

But I think those are rather enhancements than bugs as this one is